### PR TITLE
Add json run-time dependency to application list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Huex.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :httpoison]]
+    [applications: [:logger, :httpoison, :json]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
Apparently, it is best practice to list all run-time dependencies in the list of `applications`. By not listing the `json` dependency in the application list, it precludes others from using your library if they need to make a release. For example, I'm building a nerves project (Elixir embedded software) that depends on `huex`, but it is failing because the release tools do not bundle the `json` library because it is not listed in the application block. In short, both _active applications_ as well as _library applications_ should be included in the application list as best practice. See this blog post for more information: 
http://blog.plataformatec.com.br/2016/07/understanding-deps-and-applications-in-your-mixfile/
