### PR TITLE
Add Bridge discovery using `nerves_ssdp_client`

### DIFF
--- a/lib/huex/discovery.ex
+++ b/lib/huex/discovery.ex
@@ -1,0 +1,21 @@
+defmodule Huex.Discovery do
+  @moduledoc """
+  Discover Hue bridges in your network.
+
+  To use this functionality, you must include `nerves_ssdp_client` in your dependencies, as this is not installed by default.
+  """
+
+  @doc """
+  Attempts to discover any Hue bridges operating on your network. May require multiple attempts to find your bridge.
+  """
+  def discover do
+    Nerves.SSDPClient.discover |> Enum.filter(
+      fn
+        {key, %{"hue-bridgeid": _x} = map} -> true
+        _ -> false
+      end
+    )
+    |> Enum.map(fn({key, %{host: ip_address}}) -> ip_address end)
+    |> Enum.uniq
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,7 @@ defmodule Huex.Mixfile do
     [
       {:httpoison, "~> 0.11.0"},
       {:poison, "~> 3.0"},
+      {:nerves_ssdp_client, "~> 0.1", optional: true},
       {:exvcr, "~> 0.8.0", only: :test},
       {:earmark, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.14", only: :dev}

--- a/mix.lock
+++ b/mix.lock
@@ -12,6 +12,7 @@
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
+  "nerves_ssdp_client": {:hex, :nerves_ssdp_client, "0.1.3", "b09dc7433b2536399885a5f0fcd1fb58283115b075f9485f86fa713547d404dc", [], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []}}


### PR DESCRIPTION
I needed Hue Bridge discovery for the library I'm working on (http://github.com/derekkraan/domolixir). Let me know if you'd like me to make any changes.